### PR TITLE
add metadata partial.

### DIFF
--- a/ftw/jsondump/configure.zcml
+++ b/ftw/jsondump/configure.zcml
@@ -2,9 +2,12 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:i18n="http://namespaces.zope.org/i18n">
 
-    <!-- Partials -->
-    <adapter factory=".localroles.LocalRolesPartial" name="localroles"/>
+    <adapter factory=".representation.JSONRepresentation" />
+
     <include package=".archetypes" />
 
-    <adapter factory=".representation.JSONRepresentation" />
+    <!-- Partials -->
+    <adapter factory=".localroles.LocalRolesPartial" name="localroles"/>
+    <adapter factory=".metadata.MetadataPartial" name="metadata" />
+
 </configure>

--- a/ftw/jsondump/metadata.py
+++ b/ftw/jsondump/metadata.py
@@ -1,0 +1,31 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from ftw.jsondump.interfaces import IPartial
+from OFS.interfaces import IOrderedContainer
+from zope.component import adapts
+from zope.interface import implements
+from zope.interface import Interface
+
+
+class MetadataPartial(object):
+    implements(IPartial)
+    adapts(Interface, Interface)
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self, config):
+        parent = aq_parent(aq_inner(self.context))
+        klass = self.context.__class__
+
+        data = {'_classname': klass.__name__,
+                '_class': klass.__module__ + '.' + klass.__name__,
+                '_id': self.context.getId(),
+                '_obj_position_in_parent': (IOrderedContainer(parent)
+                                            .getObjectPosition(self.context.getId())),
+                '_owner': self.context.getOwner().getId(),
+                '_path': '/'.join(self.context.getPhysicalPath()),
+                '_type': self.context.portal_type}
+
+        return data

--- a/ftw/jsondump/tests/assets/archetypes_document.json
+++ b/ftw/jsondump/tests/assets/archetypes_document.json
@@ -4,6 +4,13 @@
           "Owner"
     ]
   },
+  "_class": "Products.ATContentTypes.content.document.ATDocument",
+  "_classname": "ATDocument",
+  "_id": "my-document",
+  "_obj_position_in_parent": 60,
+  "_owner": "test_user_1_",
+  "_path": "/plone/my-document",
+  "_type": "Document",
   "allowDiscussion": null,
   "contributors": [],
   "creation_date:date": "2010/12/28 10:55:12 GMT+1",

--- a/ftw/jsondump/tests/test_metadata_partial.py
+++ b/ftw/jsondump/tests/test_metadata_partial.py
@@ -1,0 +1,33 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.jsondump.interfaces import IPartial
+from ftw.jsondump.testing import FTW_JSONDUMP_INTEGRATION_TESTING
+from plone.app.testing import TEST_USER_ID
+from unittest2 import TestCase
+from zope.component import getMultiAdapter
+import json
+
+
+class TestMetadataPartial(TestCase):
+    layer = FTW_JSONDUMP_INTEGRATION_TESTING
+
+    def test_metadata_partial(self):
+        folder = create(Builder('folder'))
+        create(Builder('document').within(folder))
+        document = create(Builder('document').within(folder))
+
+        partial = getMultiAdapter((document, document.REQUEST), IPartial,
+                                  name="metadata")
+        data = partial({})
+
+        self.assertEquals(
+            {'_classname': 'ATDocument',
+             '_class': 'Products.ATContentTypes.content.document.ATDocument',
+             '_id': 'document-1',
+             '_obj_position_in_parent': 1,  # object position in parent
+             '_owner': TEST_USER_ID,
+             '_path': '/plone/folder/document-1',
+             '_type': 'Document'},
+            data)
+
+        self.assertEquals(json.loads(json.dumps(data)), data)


### PR DESCRIPTION
``` python
{'_classname': 'ATDocument',
 '_class': 'Products.ATContentTypes.content.document.ATDocument',
 '_gopip': 1,  # object position in parent
 '_owner': TEST_USER_ID,
 '_path': '/plone/folder/document-1',
 '_type': 'Document'},
```

@maethu 
