### PR TITLE
archetypes: register BaseFieldExtrator on IFloat.

### DIFF
--- a/ftw/jsondump/archetypes/base_fields.py
+++ b/ftw/jsondump/archetypes/base_fields.py
@@ -1,9 +1,13 @@
 from ftw.jsondump.interfaces import IFieldExtractor
+from Products.Archetypes.interfaces.field import IField
+from zope.component import adapts
 from zope.interface import implements
+from zope.interface import Interface
 
 
 class BaseFieldExtrator(object):
     implements(IFieldExtractor)
+    adapts(Interface, Interface, IField)
 
     def __init__(self, context, request, field):
         self.context = context

--- a/ftw/jsondump/archetypes/configure.zcml
+++ b/ftw/jsondump/archetypes/configure.zcml
@@ -5,34 +5,14 @@
     <!-- Archetypes partial -->
     <adapter factory=".fields.ArchetypesFieldsPartial" name="archetypes"/>
 
-    <!-- Base extractors, using the field getter -->
-    <adapter factory=".base_fields.BaseFieldExtrator"
-             for="* * Products.Archetypes.interfaces.field.IStringField"
-             />
-    <adapter factory=".base_fields.BaseFieldExtrator"
-             for="* * Products.Archetypes.interfaces.field.IIntegerField"
-             />
-    <adapter factory=".base_fields.BaseFieldExtrator"
-             for="* * Products.Archetypes.interfaces.field.IFloatField"
-             />
-    <adapter factory=".base_fields.BaseFieldExtrator"
-             for="* * Products.Archetypes.interfaces.field.IFixedPointField"
-             />
-    <adapter factory=".base_fields.BaseFieldExtrator"
-             for="* * Products.Archetypes.interfaces.field.IComputedField"
-             />
-    <adapter factory=".base_fields.BaseFieldExtrator"
-             for="* * Products.Archetypes.interfaces.field.IBooleanField"
-             />
-
-    <!-- Extended extractors -->
+    <adapter factory=".base_fields.BaseFieldExtrator" />
     <adapter factory=".date_field.DateFieldExtractor" />
-    <adapter factory=".lines_field.LinesFieldExtractor" />
-    <adapter factory=".text_field.TextFieldExtractor" />
-    <adapter factory=".reference_field.ReferenceFieldExtractor" />
-    <adapter factory=".file_field.FileFieldExtractor" />
-    <adapter factory=".file_field.ImageFieldExtractor" />
     <adapter factory=".file_field.FileBlobFieldExtractor" />
+    <adapter factory=".file_field.FileFieldExtractor" />
     <adapter factory=".file_field.ImageBlobFieldExtractor" />
+    <adapter factory=".file_field.ImageFieldExtractor" />
+    <adapter factory=".lines_field.LinesFieldExtractor" />
+    <adapter factory=".reference_field.ReferenceFieldExtractor" />
+    <adapter factory=".text_field.TextFieldExtractor" />
 
 </configure>


### PR DESCRIPTION
This allows us to implicitly support more fields which already store json serializable data.

@maethu 
