### PR TITLE
Add file_callback to file extractors.

### DIFF
--- a/ftw/jsondump/archetypes/file_field.py
+++ b/ftw/jsondump/archetypes/file_field.py
@@ -33,6 +33,12 @@ class FileFieldExtractor(object):
                      '{0}:size'.format(name): len(value.data),
                      '{0}:filename'.format(name): value.filename})
 
+        file_callback = config.get('file_callback', None)
+        if file_callback:
+            file_callback(self.context, name,
+                          value.data, value.filename, mimetype,
+                          data)
+
 
 class ImageFieldExtractor(FileFieldExtractor):
     adapts(Interface, Interface, IImageField)

--- a/ftw/jsondump/dexterity/namedfile.py
+++ b/ftw/jsondump/dexterity/namedfile.py
@@ -7,6 +7,8 @@ class NamedFileExtractor(PlainFieldExtractor):
     def extract(self, name, data, config):
         storage = self.field.interface(self.context)
         value = getattr(storage, name)
+        if not value:
+            return
 
         if config.get('filedata', True):
             data['{0}:file'.format(name)] = b64encode(value.data)
@@ -14,3 +16,9 @@ class NamedFileExtractor(PlainFieldExtractor):
         data['{0}:mimetype'.format(name)] = value.contentType.decode('utf-8')
         data['{0}:size'.format(name)] = value.getSize()
         data['{0}:filename'.format(name)] = value.filename.decode('utf-8')
+
+        file_callback = config.get('file_callback', None)
+        if file_callback:
+            file_callback(self.context, name,
+                          value.data, value.filename, value.contentType,
+                          data)

--- a/ftw/jsondump/tests/helpers.py
+++ b/ftw/jsondump/tests/helpers.py
@@ -1,5 +1,13 @@
 from path import Path
+from StringIO import StringIO
+
 
 def asset(filename):
     path = Path(__file__).dirname().realpath().joinpath('assets', filename)
     return path
+
+
+def asset_as_StringIO(filename):
+    result = StringIO(asset(filename).bytes())
+    result.filename = filename
+    return result

--- a/ftw/jsondump/tests/test_file_callback.py
+++ b/ftw/jsondump/tests/test_file_callback.py
@@ -1,0 +1,92 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.jsondump.interfaces import IJSONRepresentation
+from ftw.jsondump.tests.base import FtwJsondumpTestCase
+from ftw.jsondump.tests.helpers import asset
+from ftw.jsondump.tests.helpers import asset_as_StringIO
+from zope.component import getMultiAdapter
+
+
+class TestFileCallback(FtwJsondumpTestCase):
+
+    def test_archetypes_file_field(self):
+        document = create(Builder('document')
+                          .having(demo_file_field=asset_as_StringIO('helloworld.py')))
+        representation = getMultiAdapter((document, document.REQUEST), IJSONRepresentation)
+        representation.json(file_callback=self.recording_file_callback(), filedata=False)
+        self.assert_file_callback(context=document,
+                                  fieldname='demo_file_field',
+                                  data='print "Hello World"\n',
+                                  filename='helloworld.py',
+                                  mimetype='text/x-python')
+
+    def test_archetypes_file_blob_field(self):
+        document = create(Builder('document')
+                          .having(demo_file_blob_field=asset_as_StringIO('helloworld.py')))
+        representation = getMultiAdapter((document, document.REQUEST), IJSONRepresentation)
+        representation.json(file_callback=self.recording_file_callback(), filedata=False)
+        self.assert_file_callback(context=document,
+                                  fieldname='demo_file_blob_field',
+                                  data='print "Hello World"\n',
+                                  filename='helloworld.py',
+                                  mimetype='text/x-python')
+
+    def test_archetypes_image_field(self):
+        document = create(Builder('document')
+                          .having(demo_image_field=asset_as_StringIO('empty.gif')))
+        representation = getMultiAdapter((document, document.REQUEST), IJSONRepresentation)
+        representation.json(file_callback=self.recording_file_callback(), filedata=False)
+        self.assert_file_callback(context=document,
+                                  fieldname='demo_image_field',
+                                  filename='empty.gif',
+                                  mimetype='image/gif')
+
+    def test_archetypes_image_blob_field(self):
+        document = create(Builder('document')
+                          .having(demo_image_blob_field=asset_as_StringIO('empty.gif')))
+        representation = getMultiAdapter((document, document.REQUEST), IJSONRepresentation)
+        representation.json(file_callback=self.recording_file_callback(), filedata=False)
+        self.assert_file_callback(context=document,
+                                  fieldname='demo_image_blob_field',
+                                  filename='empty.gif',
+                                  mimetype='image/gif')
+
+    def test_dexterity_namedfile_field(self):
+        item = create(Builder('dx item').attach_file(asset('helloworld.py')))
+        representation = getMultiAdapter((item, item.REQUEST), IJSONRepresentation)
+        representation.json(file_callback=self.recording_file_callback(), filedata=False)
+        self.assert_file_callback(context=item,
+                                  fieldname='file_field',
+                                  data='print "Hello World"\n',
+                                  filename='helloworld.py',
+                                  mimetype='text/x-python')
+
+    def test_dexterity_namedimage_field(self):
+        item = create(Builder('dx item').attach_image(asset('empty.gif')))
+        representation = getMultiAdapter((item, item.REQUEST), IJSONRepresentation)
+        representation.json(file_callback=self.recording_file_callback(), filedata=False)
+        self.assert_file_callback(context=item,
+                                  fieldname='image_field',
+                                  filename='empty.gif',
+                                  mimetype='image/gif')
+
+    def recording_file_callback(self):
+        self.file_callback_calls = {}
+        def file_callback(context, fieldname, data, filename, mimetype, jsondata):
+            self.file_callback_calls[fieldname] = dict(
+                context=context,
+                fieldname=fieldname,
+                data=data,
+                filename=filename,
+                mimetype=mimetype)
+        return file_callback
+
+    def assert_file_callback(self, **assertions):
+        self.assertIn('fieldname', assertions,
+                      'assert_file_callback requires a "fieldname" keyword argument.')
+        fieldname = assertions['fieldname']
+        self.assertIn(fieldname, self.file_callback_calls,
+                      'file_callback was not called for field "{0}"'.format(fieldname))
+
+        data = self.file_callback_calls[fieldname]
+        self.assertDictContainsSubset(assertions, data)


### PR DESCRIPTION
The `file_callback` setting can be set to a callable, which is called for each
extracted file.  It allows to handle files differently when the user does not want
to include them in the JSON for example.

file_callback signature:
`file_callback(context, fieldname, data, filename, mimetype, jsondata)`
- `context`: The extracted Plone object.
- `fieldname`: The extracted fields' name.
- `data`: The raw file data.
- `filename`: The filename of the extracted file.
- `mimetype`: The mimetype of the extracted file.
- `jsondata`: A pointer to the partial dict which is merged into the JSON later.

@maethu 
