### PR TITLE
Rename "archetypes" and "dexterity" partials to "fields"

### DIFF
--- a/ftw/jsondump/archetypes/configure.zcml
+++ b/ftw/jsondump/archetypes/configure.zcml
@@ -3,7 +3,7 @@
     xmlns:i18n="http://namespaces.zope.org/i18n">
 
     <!-- Archetypes partial -->
-    <adapter factory=".fields.ArchetypesFieldsPartial" name="archetypes"/>
+    <adapter factory=".fields.ArchetypesFieldsPartial" name="fields"/>
 
     <adapter factory=".base_fields.BaseFieldExtrator" />
     <adapter factory=".date_field.DateFieldExtractor" />

--- a/ftw/jsondump/dexterity/configure.zcml
+++ b/ftw/jsondump/dexterity/configure.zcml
@@ -1,6 +1,6 @@
 <configure xmlns="http://namespaces.zope.org/zope">
 
-    <adapter factory=".fields.DexterityFieldsPartial" name="dexterity" />
+    <adapter factory=".fields.DexterityFieldsPartial" name="fields" />
 
     <adapter factory=".base.PlainFieldExtractor" />
 

--- a/ftw/jsondump/tests/test_archetypes_partial.py
+++ b/ftw/jsondump/tests/test_archetypes_partial.py
@@ -15,7 +15,7 @@ class TestArchetypePartial(FtwJsondumpTestCase):
     def test_partial_is_jsonseriazable(self):
         partial = getMultiAdapter((self.document, self.document.REQUEST),
                                   IPartial,
-                                  name="archetypes")
+                                  name="fields")
 
         config = {}
         partial_data = partial(config)


### PR DESCRIPTION
I'd prefer to have the name `fields` for both, the Archetypes and the Dexterity partial.
They will never conflict, as Archetypes and Dexterity are mutual exclusive.

I prefer the name `fields` however because the developer does not have to know each extracted object.
It is easier to select partials without knowing implementation details:

``` python
  representation.json(only=['fields'])
  representation.json(exclude=['fields'])
```

@maethu 
