### PR TITLE
Change file_callback signature to also include the key used in the dict.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ For doing custom things with the filedata, a callback can be used:
   from ftw.jsondump.interfaces import IJSONRepresentation
   from zope.component import getMultiAdapter
 
-  def file_callback(context, fieldname, data, filename, mimetype, jsondata):
+  def file_callback(context, key, fieldname, data, filename, mimetype, jsondata):
       with open('./tmp/' + filename, 'w+b') as target:
         target.write(data)
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,8 +1,17 @@
 Changelog
 =========
 
-1.0.1 (unreleased)
+1.1.0 (unreleased)
 ------------------
+
+- Change file_callback signature to also include the key used in the dict.
+  For dexterity content, the key is different than the fieldname because it
+  is prefixed with the interface dottedname.
+
+  - Old: ``file_callback(context, fieldname, data, filename, mimetype, jsondata)``
+  - New: ``file_callback(context, key, fieldname, data, filename, mimetype, jsondata)``
+
+  [jone]
 
 - Dexterity: support exporting RichTextValue objects.
   [jone]

--- a/ftw/jsondump/archetypes/file_field.py
+++ b/ftw/jsondump/archetypes/file_field.py
@@ -35,7 +35,7 @@ class FileFieldExtractor(object):
 
         file_callback = config.get('file_callback', None)
         if file_callback:
-            file_callback(self.context, name,
+            file_callback(self.context, name, name,
                           value.data, value.filename, mimetype,
                           data)
 

--- a/ftw/jsondump/dexterity/namedfile.py
+++ b/ftw/jsondump/dexterity/namedfile.py
@@ -19,6 +19,6 @@ class NamedFileExtractor(PlainFieldExtractor):
 
         file_callback = config.get('file_callback', None)
         if file_callback:
-            file_callback(self.context, name,
+            file_callback(self.context, self.key, name,
                           value.data, value.filename, value.contentType,
                           data)

--- a/ftw/jsondump/tests/test_file_callback.py
+++ b/ftw/jsondump/tests/test_file_callback.py
@@ -15,6 +15,7 @@ class TestFileCallback(FtwJsondumpTestCase):
         representation = getMultiAdapter((document, document.REQUEST), IJSONRepresentation)
         representation.json(file_callback=self.recording_file_callback(), filedata=False)
         self.assert_file_callback(context=document,
+                                  key='demo_file_field',
                                   fieldname='demo_file_field',
                                   data='print "Hello World"\n',
                                   filename='helloworld.py',
@@ -26,6 +27,7 @@ class TestFileCallback(FtwJsondumpTestCase):
         representation = getMultiAdapter((document, document.REQUEST), IJSONRepresentation)
         representation.json(file_callback=self.recording_file_callback(), filedata=False)
         self.assert_file_callback(context=document,
+                                  key='demo_file_blob_field',
                                   fieldname='demo_file_blob_field',
                                   data='print "Hello World"\n',
                                   filename='helloworld.py',
@@ -37,6 +39,7 @@ class TestFileCallback(FtwJsondumpTestCase):
         representation = getMultiAdapter((document, document.REQUEST), IJSONRepresentation)
         representation.json(file_callback=self.recording_file_callback(), filedata=False)
         self.assert_file_callback(context=document,
+                                  key='demo_image_field',
                                   fieldname='demo_image_field',
                                   filename='empty.gif',
                                   mimetype='image/gif')
@@ -47,6 +50,7 @@ class TestFileCallback(FtwJsondumpTestCase):
         representation = getMultiAdapter((document, document.REQUEST), IJSONRepresentation)
         representation.json(file_callback=self.recording_file_callback(), filedata=False)
         self.assert_file_callback(context=document,
+                                  key='demo_image_blob_field',
                                   fieldname='demo_image_blob_field',
                                   filename='empty.gif',
                                   mimetype='image/gif')
@@ -56,6 +60,7 @@ class TestFileCallback(FtwJsondumpTestCase):
         representation = getMultiAdapter((item, item.REQUEST), IJSONRepresentation)
         representation.json(file_callback=self.recording_file_callback(), filedata=False)
         self.assert_file_callback(context=item,
+                                  key='ftw.jsondump.tests.dxitem.IDXItemSchema.file_field',
                                   fieldname='file_field',
                                   data='print "Hello World"\n',
                                   filename='helloworld.py',
@@ -66,15 +71,17 @@ class TestFileCallback(FtwJsondumpTestCase):
         representation = getMultiAdapter((item, item.REQUEST), IJSONRepresentation)
         representation.json(file_callback=self.recording_file_callback(), filedata=False)
         self.assert_file_callback(context=item,
+                                  key='ftw.jsondump.tests.dxitem.IDXItemSchema.image_field',
                                   fieldname='image_field',
                                   filename='empty.gif',
                                   mimetype='image/gif')
 
     def recording_file_callback(self):
         self.file_callback_calls = {}
-        def file_callback(context, fieldname, data, filename, mimetype, jsondata):
+        def file_callback(context, key, fieldname, data, filename, mimetype, jsondata):
             self.file_callback_calls[fieldname] = dict(
                 context=context,
+                key=key,
                 fieldname=fieldname,
                 data=data,
                 filename=filename,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.0.1.dev0'
+version = '1.1.0.dev0'
 
 tests_require = [
     'AccessControl',


### PR DESCRIPTION
~~#16~~
Change file_callback signature to also include the key used in the dict.
For dexterity content, the key is different than the fieldname because it is prefixed with the interface dottedname.

Old: `file_callback(context, fieldname, data, filename, mimetype, jsondata)`
New: `file_callback(context, key, fieldname, data, filename, mimetype, jsondata)`

This change is necessary so that we know for dexterity items which key in the jsondata to change, e.g. when we want to remove the filedata because we store it seperately.
