### PR TITLE
Add configuration option "field_dottednames"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,24 @@ For doing custom things with the filedata, a callback can be used:
   print json_representation.json(file_callback=file_callback)
 
 
+**Field names**
+
+By default, dexterity fields are represented with the full dottedname as key
+in order to avoid conflicts when having the same field name in multiple
+dexterity behavior schemas.
+
+Example: ``plone.app.dexterity.behaviors.metadata.IBasic.title``.
+
+This behavior can be disabled with the ``field_dottednames`` configuration option:
+
+.. code:: python
+
+  from ftw.jsondump.interfaces import IJSONRepresentation
+  from zope.component import getMultiAdapter
+
+  json_representation = getMultiAdapter((context, request), IJSONRepresentation)
+  print json_representation.json(field_dottednames=False)
+
 Creating custom partials
 ------------------------
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- Add configuration option ``field_dottednames``
+  in order to use short fieldnames.
+  [jone]
+
 - Ignore missing partials when seleting with "only".
   [jone]
 

--- a/ftw/jsondump/dexterity/base.py
+++ b/ftw/jsondump/dexterity/base.py
@@ -15,16 +15,20 @@ class PlainFieldExtractor(object):
         self.field = field
 
     def extract(self, name, data, config):
+        key = self.key(config)
         storage = self.field.interface(self.context)
         value = getattr(storage, name)
         value = self.convert(value)
-        data.update({self.key: value})
+        data.update({key: value})
 
-    @property
-    def key(self):
-        return '.'.join((
-                self.field.interface.__identifier__,
-                self.field.__name__))
+    def key(self, config):
+        if config.get('field_dottednames', True):
+            return '.'.join((
+                    self.field.interface.__identifier__,
+                    self.field.__name__))
+
+        else:
+            return self.field.__name__
 
     def convert(self, value):
         return value

--- a/ftw/jsondump/dexterity/namedfile.py
+++ b/ftw/jsondump/dexterity/namedfile.py
@@ -5,21 +5,22 @@ from ftw.jsondump.dexterity.base import PlainFieldExtractor
 class NamedFileExtractor(PlainFieldExtractor):
 
     def extract(self, name, data, config):
+        key = self.key(config)
         storage = self.field.interface(self.context)
         value = getattr(storage, name)
         if not value:
             return
 
         if config.get('filedata', True):
-            data['{0}:file'.format(self.key)] = b64encode(value.data)
+            data['{0}:file'.format(key)] = b64encode(value.data)
 
-        data['{0}:mimetype'.format(self.key)] = (
+        data['{0}:mimetype'.format(key)] = (
             value.contentType.decode('utf-8'))
-        data['{0}:size'.format(self.key)] = value.getSize()
-        data['{0}:filename'.format(self.key)] = value.filename.decode('utf-8')
+        data['{0}:size'.format(key)] = value.getSize()
+        data['{0}:filename'.format(key)] = value.filename.decode('utf-8')
 
         file_callback = config.get('file_callback', None)
         if file_callback:
-            file_callback(self.context, self.key, name,
+            file_callback(self.context, key, name,
                           value.data, value.filename, value.contentType,
                           data)

--- a/ftw/jsondump/dexterity/richtext.py
+++ b/ftw/jsondump/dexterity/richtext.py
@@ -5,12 +5,13 @@ from plone.app.textfield.value import RichTextValue
 class RichTextExtractor(PlainFieldExtractor):
 
     def extract(self, name, data, config):
+        key = self.key(config)
         storage = self.field.interface(self.context)
         value = getattr(storage, name)
         if isinstance(value, RichTextValue):
-            data.update({self.key: value.raw,
-                         self.key + ':mimeType': value.mimeType,
-                         self.key + ':outputMimeType': value.outputMimeType,
-                         self.key + ':encoding': value.encoding})
+            data.update({key: value.raw,
+                         key + ':mimeType': value.mimeType,
+                         key + ':outputMimeType': value.outputMimeType,
+                         key + ':encoding': value.encoding})
         else:
-            data[self.key] = value
+            data[key] = value

--- a/ftw/jsondump/tests/test_dexterity_partial.py
+++ b/ftw/jsondump/tests/test_dexterity_partial.py
@@ -1,0 +1,22 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.jsondump.interfaces import IPartial
+from ftw.jsondump.tests.base import FtwJsondumpTestCase
+from zope.component import getMultiAdapter
+
+
+class TestDexterityPatial(FtwJsondumpTestCase):
+
+    def test_field_dottednames_enabled_by_default(self):
+        item = create(Builder('dx item').titled(u'Foo'))
+        partial = getMultiAdapter((item, None), IPartial, name="fields")
+        self.assertDictContainsSubset(
+            {u'plone.app.dexterity.behaviors.metadata.IBasic.title': u'Foo'},
+            partial(config={}))
+
+    def test_disabling_field_dottednames(self):
+        item = create(Builder('dx item').titled(u'Foo'))
+        partial = getMultiAdapter((item, None), IPartial, name="fields")
+        self.assertDictContainsSubset(
+            {u'title': u'Foo'},
+            partial(config={'field_dottednames': False}))


### PR DESCRIPTION
The configuration option allows to disable the dottedname prefix for
dexterity fields (`field_dottednames=False`).
By default, the dottedname prefix is still applied in order to avoid
fieldname conflicts when using the same name in multpile behaviors.
